### PR TITLE
add recorder/playback to edit

### DIFF
--- a/R/edit.R
+++ b/R/edit.R
@@ -177,7 +177,7 @@ editFeatures.sf = function(
   # return merged features
   if(record==TRUE) {
     return(list(
-      merged = merged,
+      features = merged,
       recorder = recorder
     ))
   }

--- a/R/edit.R
+++ b/R/edit.R
@@ -82,8 +82,13 @@ editMap.mapview <- function(
   stopifnot(!is.null(x), inherits(x, "mapview"), inherits(x@map, "leaflet"))
 
   editMap.leaflet(
+<<<<<<< HEAD
     x@map, targetLayerId = targetLayerId, sf = sf,
     ns = ns, viewer = viewer, record = TRUE)
+=======
+    x@map, targetLayerId = targetLayerId, sf = sf, ns = ns, record = record
+  )
+>>>>>>> change record to add attribute for return value consistency
 }
 
 
@@ -136,11 +141,6 @@ editFeatures.sf = function(
 
   crud = editMap(m, targetLayerId = "toedit", record = record, ...)
 
-  if(record == TRUE) {
-    recorder = crud$recorder
-    crud = crud$features
-  }
-
   merged <- Reduce(
     function(left_sf, op) {
       op <- tolower(op)
@@ -176,10 +176,7 @@ editFeatures.sf = function(
 
   # return merged features
   if(record==TRUE) {
-    return(list(
-      features = merged,
-      recorder = recorder
-    ))
+    attr(merged, "recorder") <- attr(crud, "recorder", exact=TRUE)
   }
   return(merged)
 }

--- a/R/edit.R
+++ b/R/edit.R
@@ -24,10 +24,11 @@ editMap <- function(x, viewer, ...) {
 #'          If \code{sf = FALSE}, \code{GeoJSON} will be returned.
 #' @param ns \code{string} name for the Shiny \code{namespace} to use.  The \code{ns}
 #'          is unlikely to require a change.
+#' @param record \code{logical} to record all edits for future playback.
 #' @export
 editMap.leaflet <- function(
   x = NULL, targetLayerId = NULL, sf = TRUE,
-  ns = "mapedit-edit", viewer = shiny::paneViewer(), ...
+  ns = "mapedit-edit", record = FALSE, viewer = shiny::paneViewer(), ...
 ) {
   stopifnot(!is.null(x), inherits(x, "leaflet"))
 
@@ -49,7 +50,8 @@ editMap.leaflet <- function(
       ns,
       x,
       targetLayerId = targetLayerId,
-      sf = sf
+      sf = sf,
+      record = record
     )
 
     observe({crud()})
@@ -75,14 +77,13 @@ editMap.leaflet <- function(
 #' @export
 editMap.mapview <- function(
   x = NULL, targetLayerId = NULL, sf = TRUE,
-  ns = "mapedit-edit", viewer = shiny::paneViewer(), ...
+  ns = "mapedit-edit", record = FALSE, viewer = shiny::paneViewer(), ...
 ) {
   stopifnot(!is.null(x), inherits(x, "mapview"), inherits(x@map, "leaflet"))
 
   editMap.leaflet(
     x@map, targetLayerId = targetLayerId, sf = sf,
-    ns = ns, viewer = viewer
-  )
+    ns = ns, viewer = viewer, record = TRUE)
 }
 
 
@@ -104,11 +105,13 @@ editFeatures = function(x, ...) {
 #' @param mergeOrder \code{vector} or \code{character} arguments to specify the order
 #'          of merge operations.  By default, merges will proceed in the order
 #'          of add, edit, delete.
+#' @param record \code{logical} to record all edits for future playback.
 #' @export
 editFeatures.sf = function(
   x,
   platform = c("mapview", "leaflet"),
   mergeOrder = c("add", "edit", "delete"),
+  record = FALSE,
   ...
 ) {
 
@@ -131,7 +134,12 @@ editFeatures.sf = function(
     m = mapview::addFeatures(m, data=x, layerId=~x$edit_id, group = "toedit")
   }
 
-  crud = editMap(m, targetLayerId = "toedit", ...)
+  crud = editMap(m, targetLayerId = "toedit", record = record, ...)
+
+  if(record == TRUE) {
+    recorder = crud$recorder
+    crud = crud$features
+  }
 
   merged <- Reduce(
     function(left_sf, op) {
@@ -167,6 +175,12 @@ editFeatures.sf = function(
   )
 
   # return merged features
+  if(record==TRUE) {
+    return(list(
+      merged = merged,
+      recorder = recorder
+    ))
+  }
   return(merged)
 }
 

--- a/R/edit.R
+++ b/R/edit.R
@@ -82,13 +82,9 @@ editMap.mapview <- function(
   stopifnot(!is.null(x), inherits(x, "mapview"), inherits(x@map, "leaflet"))
 
   editMap.leaflet(
-<<<<<<< HEAD
     x@map, targetLayerId = targetLayerId, sf = sf,
-    ns = ns, viewer = viewer, record = TRUE)
-=======
-    x@map, targetLayerId = targetLayerId, sf = sf, ns = ns, record = record
+    ns = ns, viewer = viewer, record = TRUE
   )
->>>>>>> change record to add attribute for return value consistency
 }
 
 

--- a/R/modules.R
+++ b/R/modules.R
@@ -249,8 +249,9 @@ editMod <- function(
         }
       )
     }
-    if(record == TRUE) {
-      return(list(features=workinglist, recorder=recorder))
+    # return merged features
+    if(record==TRUE) {
+      attr(workinglist, "recorder") <- recorder
     }
     return(workinglist)
   })

--- a/R/modules.R
+++ b/R/modules.R
@@ -193,6 +193,7 @@ editMod <- function(
             list(
               list(
                 event = evt,
+                timestamp = Sys.time(),
                 feature = input[[evt]]
               )
             )

--- a/R/modules.R
+++ b/R/modules.R
@@ -246,7 +246,7 @@ editMod <- function(
         recorder,
         function(evt) {
           feature = st_as_sfc.geo_list(evt$feature)
-          list(evt = evt$event, feature = feature)
+          list(evt = evt$event, timestamp = evt$timestamp, feature = feature)
         }
       )
     }

--- a/R/modules.R
+++ b/R/modules.R
@@ -96,6 +96,7 @@ editModUI <- function(id, ...) {
 #' @param targetLayerId \code{character} identifier of layer to edit, delete
 #' @param sf \code{logical} to return simple features.  \code{sf=FALSE} will return
 #'          \code{GeoJSON}.
+#' @param record \code{logical} to record all edits for future playback.
 #'
 #' @return server function for Shiny module
 #' @import shiny
@@ -104,7 +105,8 @@ editMod <- function(
   input, output, session,
   leafmap,
   targetLayerId = NULL,
-  sf = TRUE
+  sf = TRUE,
+  record = FALSE
 ) {
   # check to see if addDrawToolbar has been already added to the map
   if(is.null(
@@ -136,6 +138,8 @@ editMod <- function(
     deleted_all = list(),
     finished = list()
   )
+
+  recorder <- list()
 
   EVT_DRAW <- "map_draw_new_feature"
   EVT_EDIT <- "map_draw_edited_features"
@@ -178,6 +182,26 @@ editMod <- function(
     featurelist$deleted_all <- c(featurelist$deleted_all, list(deleted))
   })
 
+  # record events if record = TRUE
+  if(record == TRUE) {
+    lapply(
+      c(EVT_DRAW, EVT_EDIT, EVT_DELETE),
+      function(evt) {
+        observeEvent(input[[evt]], {
+          recorder <<- c(
+            recorder,
+            list(
+              list(
+                event = evt,
+                feature = input[[evt]]
+              )
+            )
+          )
+        })
+      }
+    )
+  }
+
 
   # collect all of the the features into a list
   #  by action
@@ -217,6 +241,16 @@ editMod <- function(
           )
         }
       )
+      recorder <- lapply(
+        recorder,
+        function(evt) {
+          feature = st_as_sfc.geo_list(evt$feature)
+          list(evt = evt$event, feature = feature)
+        }
+      )
+    }
+    if(record == TRUE) {
+      return(list(features=workinglist, recorder=recorder))
     }
     return(workinglist)
   })

--- a/man/editFeatures.Rd
+++ b/man/editFeatures.Rd
@@ -11,7 +11,7 @@
 editFeatures(x, ...)
 
 \method{editFeatures}{sf}(x, platform = c("mapview", "leaflet"),
-  mergeOrder = c("add", "edit", "delete"), ...)
+  mergeOrder = c("add", "edit", "delete"), record = FALSE, ...)
 
 \method{editFeatures}{Spatial}(x, ...)
 }
@@ -26,6 +26,8 @@ the type of map you would like to use for editing}
 \item{mergeOrder}{\code{vector} or \code{character} arguments to specify the order
 of merge operations.  By default, merges will proceed in the order
 of add, edit, delete.}
+
+\item{record}{\code{logical} to record all edits for future playback.}
 }
 \description{
 Interactively Edit Map Features

--- a/man/editMap.Rd
+++ b/man/editMap.Rd
@@ -11,10 +11,10 @@
 editMap(x, viewer, ...)
 
 \method{editMap}{leaflet}(x = NULL, targetLayerId = NULL, sf = TRUE,
-  ns = "mapedit-edit", viewer = shiny::paneViewer(), ...)
+  ns = "mapedit-edit", record = FALSE, viewer = shiny::paneViewer(), ...)
 
 \method{editMap}{mapview}(x = NULL, targetLayerId = NULL, sf = TRUE,
-  ns = "mapedit-edit", viewer = shiny::paneViewer(), ...)
+  ns = "mapedit-edit", record = FALSE, viewer = shiny::paneViewer(), ...)
 }
 \arguments{
 \item{x}{\code{leaflet} or \code{mapview} map to edit}
@@ -30,6 +30,8 @@ If \code{sf = FALSE}, \code{GeoJSON} will be returned.}
 
 \item{ns}{\code{string} name for the Shiny \code{namespace} to use.  The \code{ns}
 is unlikely to require a change.}
+
+\item{record}{\code{logical} to record all edits for future playback.}
 }
 \value{
 \code{sf} simple features or \code{GeoJSON}

--- a/man/editMod.Rd
+++ b/man/editMod.Rd
@@ -4,7 +4,8 @@
 \alias{editMod}
 \title{Shiny Module Server for Geo Create, Edit, Delete}
 \usage{
-editMod(input, output, session, leafmap, targetLayerId = NULL, sf = TRUE)
+editMod(input, output, session, leafmap, targetLayerId = NULL, sf = TRUE,
+  record = FALSE)
 }
 \arguments{
 \item{input}{Shiny server function input}
@@ -19,6 +20,8 @@ editMod(input, output, session, leafmap, targetLayerId = NULL, sf = TRUE)
 
 \item{sf}{\code{logical} to return simple features.  \code{sf=FALSE} will return
 \code{GeoJSON}.}
+
+\item{record}{\code{logical} to record all edits for future playback.}
 }
 \value{
 server function for Shiny module


### PR DESCRIPTION
Add `record` argument to the `edit*` functions for reproducibility of edits.  If `record = TRUE`, then the returned object will get a `recorder` attribute with the series of actions.